### PR TITLE
Density Descriptions for Mapper-Based Clustering

### DIFF
--- a/src/modeling/model.py
+++ b/src/modeling/model.py
@@ -11,6 +11,7 @@ from model_helper import (
     config_plot_data,
     custom_color_scale,
     mapper_plot_outfile,
+    get_minimal_std,
 )
 
 
@@ -138,10 +139,24 @@ class Model:
         self._cluster_ids = labels
 
     def compute_node_descriptions(self):
-        pass
+        nodes = self.complex["nodes"]
+        self._node_description = {}
+        for node in nodes.keys():
+            mask = nodes[node]
+            label = get_minimal_std(
+                df=self.tupper.clean,
+                mask=mask,
+            )
+            self._node_description[node] = label
 
     def compute_cluster_descriptions(self):
-        pass
+        """Choose the column in the `tupper.clean` with the lowest standard deviation."""
+        clusters = np.unique(self.cluster_ids)
+        self._cluster_description = {}
+        for cluster in clusters:
+            mask = np.array(np.where(self.cluster_ids == cluster, 1, 0), dtype=bool)
+            label = get_minimal_std(df=self.tupper.clean, mask=mask)
+            self._cluster_description[cluster] = label
 
     def visualize_mapper(self):
         assert len(self.complex) > 0, "Model needs a `fitted` mapper."

--- a/src/modeling/model_helper.py
+++ b/src/modeling/model_helper.py
@@ -1,16 +1,22 @@
 "Helper functions for Mapper Policy Model"
 
-import datetime
 import os
 import sys
 
+import numpy as np
+import pandas as pd
 from dotenv import load_dotenv
-
 
 load_dotenv()
 root = os.getenv("root")
 src = os.getenv("src")
 sys.path.append(src)
+
+
+def get_minimal_std(df: pd.DataFrame, mask: np.array):
+    subset = df.iloc[mask]
+    col_label = subset.columns[subset.std(axis=0).argmin()]
+    return col_label
 
 
 def mapper_plot_outfile(


### PR DESCRIPTION
Checkout the member functions in `model.py`:

### Functions
1. `compute_node_descriptions`: this looks at each node and assigns it a "label", i.e. the column in `tupper.clean` with the lowest standard deviation. (note this is looking at scaled data so we can directly compare the standard deviations, as they are normalized). 
2. `compute_cluster_descriptions`: this looks at each node in a connected component and using the labeling assigned by (1), and returns a probability distribution over the columns in `tupper.clean`. 

### Sample Code:

Initialize Model
`my_model = Model(file)`
`my_model.node_descriptions`
Output:
```
{
'cube12_cluster0': {'label': 'securitization_policy', 'size': 8},
 'cube12_cluster1': {'label': 'legislation_majority_party', 'size': 9},
 'cube16_cluster0': {'label': 'Retrofit Costs', 'size': 14},
 'cube16_cluster1': {'label': 'forwardCosts', 'size': 10},
 'cube17_cluster0': {'label': 'legislation_majority_party', 'size': 6},
 'cube17_cluster1': {'label': 'ret_STATUS', 'size': 7},
 'cube18_cluster0': {'label': 'securitization_policy', 'size': 8},
 'cube18_cluster1': {'label': 'legislation_majority_party', 'size': 8},
 'cube29_cluster0': {'label': 'legislation_majority_party', 'size': 6},
 'cube29_cluster1': {'label': 'Retrofit Costs', 'size': 8},
 'cube30_cluster0': {'label': 'Retrofit Costs', 'size': 11},
 'cube30_cluster1': {'label': 'Retrofit Costs', 'size': 8},
 'cube35_cluster0': {'label': 'PLSO2AN', 'size': 13},
 'cube35_cluster1': {'label': 'Retrofit Costs', 'size': 8},
 'cube37_cluster0': {'label': 'legislation_majority_party', 'size': 12},
 'cube37_cluster1': {'label': 'securitization_policy', 'size': 6},
 'cube38_cluster0': {'label': 'legislation_majority_party', 'size': 8},
 'cube38_cluster1': {'label': 'Retrofit Costs', 'size': 7},
 'cube39_cluster0': {'label': 'forwardCosts', 'size': 16},
 'cube39_cluster1': {'label': 'Retrofit Costs', 'size': 7},
 'cube44_cluster0': {'label': 'PLSO2AN', 'size': 13},
 'cube44_cluster1': {'label': 'Retrofit Costs', 'size': 8}
 }
```


`my_model.cluster_descriptions`

Output:
```
{
0: {'density': {'securitization_policy': 1.0}, 'size': 8},
 1: {'density': {'legislation_majority_party': 1.0}, 'size': 9},
 2: {'density': {'Retrofit Costs': 0.67, 'ret_STATUS': 0.33}, 'size': 14},
 3: {'density': {'forwardCosts': 1.0}, 'size': 10},
 4: {'density': {'legislation_majority_party': 1.0}, 'size': 9},
 5: {'density': {'legislation_majority_party': 1.0}, 'size': 12},
 6: {'density': {'Retrofit Costs': 1.0}, 'size': 8},
 7: {'density': {'Retrofit Costs': 0.41, 'forwardCosts': 0.59}, 'size': 17},
 8: {'density': {'PLSO2AN': 1.0}, 'size': 13},
 9: {'density': {'Retrofit Costs': 0.73, 'securitization_policy': 0.27},
  'size': 10},
 -1: {'density': {'forwardCosts': 1.0}, 'size': 161}
}

```