### PR TITLE
Added Unqiue Samples Filter for Clustering Models  

### DIFF
--- a/src/modeling/coal_mapper_generator.py
+++ b/src/modeling/coal_mapper_generator.py
@@ -142,6 +142,7 @@ if __name__ == "__main__":
                 nbors,
                 d,
                 hdbscan_params,
+                val,
             )
 
             out_dir_message = output_file

--- a/src/tuning/metrics/metric_generator.py
+++ b/src/tuning/metrics/metric_generator.py
@@ -22,6 +22,13 @@ if __name__ == "__main__":
         default="landscape",
         help="Select metric (that is supported by Giotto) to compare persistence daigrams.",
     )
+    parser.add_argument(
+        "-f",
+        "--coverage_filter",
+        type=float,
+        default=0.8,
+        help="Select the percentage of unqiue samples that need to be covered by Mapper's fit.",
+    )
 
     parser.add_argument(
         "-n",
@@ -52,7 +59,9 @@ if __name__ == "__main__":
     n = args.num_policy_groups
     path_to_mappers = os.path.join(root, f"data/mappers/{n}_policy_groups")
 
-    keys, distances = topology_metric(files=path_to_mappers, metric=args.metric)
+    keys, distances = topology_metric(
+        files=path_to_mappers, metric=args.metric, coverage=args.coverage_filter
+    )
     results = {"keys": keys, "distances": distances}
 
     if args.save:

--- a/src/tuning/metrics/metric_helper.py
+++ b/src/tuning/metrics/metric_helper.py
@@ -45,10 +45,11 @@ def mapper_reader(dir):
         if file.endswith(".pkl"):
             mapper_file = os.path.join(dir, file)
             with open(mapper_file, "rb") as f:
-                result_dictionary = pickle.load(f)
-            hyper_params = result_dictionary["hyperparameters"]
-            result_dictionary.pop("hyperparameters")
-            data[hyper_params] = result_dictionary
+                reference = pickle.load(f)
+
+            mapper = reference["mapper"]
+            hyper_params = reference["hyperparameters"]
+            data[hyper_params] = mapper
 
     return data
 

--- a/src/tuning/policy_clustering/policy_clusterer.py
+++ b/src/tuning/policy_clustering/policy_clusterer.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         out_dir_message = f"{model_file} successfully written."
 
         output_dir = os.path.join(
-            root, f"data/parameter_modeling/models/{n}_policy_groups/"
+            root, f"data/model_analysis/models/{n}_policy_groups/"
         )
 
         # Check if output directory already exists


### PR DESCRIPTION
using the `-f` tag in `metric_generator.py` you can now set a "coverage filter" that determines which models are included in the hierarchical clustering model (sklearn model is written to pickle, so go here for details) and corresponding dendrogram.  