### PR TITLE
Density update

### DIFF
--- a/src/modeling/model.py
+++ b/src/modeling/model.py
@@ -214,7 +214,7 @@ class Model:
 
         As a note, we only consider columns that are:
             1) continuous in the raw data
-            2) used to fit JMapper
+            2) used to fit JMapper, i.e. appear in clean data
 
         Returns
         -------
@@ -325,18 +325,26 @@ class Model:
             subframes[df_label] = raw_subframe
         return subframes
 
-    def visualize_model(self):
+    def visualize_model(self, k=None):
         """
         Visualize the clustering as a network. This function plots
         the JMapper's graph in a matplotlib figure, coloring the nodes
         by their respective policy group.
+
+        Parameters
+        -------
+        k : float, default is None
+            Optimal distance between nodes. If None the distance is set to
+            1/sqrt(n) where n is the number of nodes. Increase this value to
+            move nodes farther apart.
+
         """
         # Config Pyplot
         fig = plt.figure(figsize=(8, 8))
         ax = fig.add_subplot()
         color_scale = np.array(custom_color_scale()).T[1]
         # Get Node Coords
-        pos = nx.spring_layout(self.mapper.graph)
+        pos = nx.spring_layout(self.mapper.graph, k=k)
 
         # Plot and color components
         components, labels = zip(*self.mapper.components.items())
@@ -358,11 +366,11 @@ class Model:
                 width=2,
                 ax=ax,
                 label=None,
+                alpha=0.6,
             )
         ax.legend(loc="best", prop={"size": 8})
         plt.axis("off")
 
-    # TODO: 1) Fix Color Scale and match with visualize_model
     def visualize_projection(self):
         """
         Visualize the clustering on the projection point cloud.

--- a/src/modeling/model_helper.py
+++ b/src/modeling/model_helper.py
@@ -136,7 +136,7 @@ def generate_model_filename(args, n_neighbors, min_dist, min_intersection):
     return output_file
 
 
-def get_minimal_std(df: pd.DataFrame, mask: np.array):
+def get_minimal_std(df: pd.DataFrame, mask: np.array, density_cols=None):
     """Find the column with the minimal standard deviation
     within a subset of a Dataframe.
 
@@ -155,8 +155,10 @@ def get_minimal_std(df: pd.DataFrame, mask: np.array):
         The index idenitfier for the column in the dataframe with minimal std.
 
     """
-    subset = df.iloc[mask]
-    col_label = subset.columns[subset.std(axis=0).argmin()]
+    if density_cols is None:
+        density_cols = df.columns
+    sub_df = df.iloc[mask][density_cols]
+    col_label = sub_df.columns[sub_df.std(axis=0).argmin()]
     return col_label
 
 
@@ -236,7 +238,7 @@ def custom_color_scale():
         [0.8, "#ae2012"],
         [0.9, "#9b2226"],
         [0.95, "#a50026"],
-        [1.0, "#f5d225"]
+        [1.0, "#f5d225"],
     ]
     return colorscale
 


### PR DESCRIPTION
Node descriptors now are generated by lowest (normalized) standard deviation across continuous variables. Columns to choose from are described as:

1) continuous or "numeric" in the raw data
2) used to fit JMapper, i.e. they also appear in the clean data 


Also, added a `k` parameter so you can tweak the node distance when visualizing models. Some of the ones I've been looking at, the larger clusters have very interesting structure that can only be seen when you increase k 